### PR TITLE
FIx syntax error in rails engine template

### DIFF
--- a/rails_template.rb
+++ b/rails_template.rb
@@ -83,7 +83,7 @@ Autotune.configure do |conf|
       'body_font_family' => 'Georgia Regular, serif',
       'header_font_family' => 'Georgia Bold, serif',
       'button_font_family' => 'Georgia Regular, serif',
-      'header_font_weight' => 700
+      'header_font_weight' => 700,
       'button_font_weight' => 'normal'
     },
     'social' => {


### PR DESCRIPTION
Just adds a missing comma in the font hash of the rails engine template.

![](http://www.brandandmortar.com/wp-content/uploads/2015/07/copywriting-guide-cartoon-comma.jpg)

(I am using this for a non-vox experiment, and I ran into this when I was creating a new autotune app locally)