### PR TITLE
Enable Read-only API use for users without google accounts (when required)

### DIFF
--- a/app/controllers/autotune/application_controller.rb
+++ b/app/controllers/autotune/application_controller.rb
@@ -124,7 +124,7 @@ module Autotune
     end
 
     def require_google_login
-      if signed_in? && any_roles? && !has_google_auth? && !accepts_json?
+      if signed_in? && any_roles? && !has_google_auth?
         respond_to do |format|
           format.html { render 'google_auth' }
           format.json { render_error 'Unauthorized', :unauthorized }

--- a/app/controllers/autotune/projects_controller.rb
+++ b/app/controllers/autotune/projects_controller.rb
@@ -5,8 +5,15 @@ require 'redis'
 module Autotune
   # API for projects
   class ProjectsController < ApplicationController
-    before_action :respond_to_html
     model Project
+    skip_before_action :require_google_login,
+                       :only => [:index, :show]
+
+    before_action :only => [:index, :show] do
+      require_google_login if google_auth_required? && !accepts_json?
+    end
+
+    before_action :respond_to_html
 
     rescue_from ActiveRecord::UnknownAttributeError do |exc|
       render_error exc.message, :bad_request

--- a/app/controllers/autotune/projects_controller.rb
+++ b/app/controllers/autotune/projects_controller.rb
@@ -12,7 +12,7 @@ module Autotune
       render_error exc.message, :bad_request
     end
 
-    before_action :only => [:show, :update,:update_snapshot, :destroy, :build, :build_and_publish] do
+    before_action :only => [:show, :update, :update_snapshot, :destroy, :build, :build_and_publish] do
       unless current_user.role?(:superuser) ||
              instance.user == current_user ||
              current_user.role?(:editor => instance.group.slug) ||

--- a/test/autotune_test_helper.rb
+++ b/test/autotune_test_helper.rb
@@ -91,9 +91,13 @@ class ActiveSupport::TestCase
       "#{Dir.tmpdir}/#{Time.now.to_i}#{rand(1000)}/")
     # puts 'Working dir: ' + Rails.configuration.autotune.working_dir
     FileUtils.mkdir_p(Rails.configuration.autotune.working_dir)
+
+    @tmp_gauth_flag = Rails.configuration.autotune.google_auth_enabled
   end
 
   def teardown
+    Rails.configuration.autotune.google_auth_enabled = @tmp_gauth_flag
+
     FileUtils.rm_rf(Rails.configuration.autotune.working_dir) \
       if File.exist?(Rails.configuration.autotune.working_dir)
     %w(preview publish media).each do |dir|
@@ -107,10 +111,6 @@ class ActiveSupport::TestCase
   def mock_auth
     OmniAuth.config.mock_auth
   end
-
-  #def repo_url
-    #File.expand_path('../repos/autotune-example-blueprint.git', __FILE__).to_s
-  #end
 end
 
 # Helpers for controller tests

--- a/test/controllers/autotune/projects_controller_test.rb
+++ b/test/controllers/autotune/projects_controller_test.rb
@@ -369,6 +369,25 @@ module Autotune
       assert_equal LIVE_HEAD1, new_p.blueprint_version
     end
 
+    test 'json request not blocked by google auth requirement' do
+      tmp = Autotune.config.google_auth_enabled
+      Autotune.config.google_auth_enabled = true
+      valid_auth_header!
+      get :index
+      assert_response :ok
+      assert_match 'Please authenticate with Google', response.body,
+                   'Should display message about logging in with Google'
+
+      accept_json!
+
+      get :index
+      assert_response :success
+      assert_instance_of Array, decoded_response
+      assert_equal Project.all.count, decoded_response.length
+
+      Autotune.config.google_auth_enabled = tmp
+    end
+
     private
 
     def assert_project_data!

--- a/test/controllers/autotune/projects_controller_test.rb
+++ b/test/controllers/autotune/projects_controller_test.rb
@@ -370,9 +370,9 @@ module Autotune
     end
 
     test 'json request not blocked by google auth requirement' do
-      tmp = Autotune.config.google_auth_enabled
       Autotune.config.google_auth_enabled = true
       valid_auth_header!
+
       get :index
       assert_response :ok
       assert_match 'Please authenticate with Google', response.body,
@@ -381,11 +381,9 @@ module Autotune
       accept_json!
 
       get :index
-      assert_response :success
+      assert_response :ok
       assert_instance_of Array, decoded_response
       assert_equal Project.all.count, decoded_response.length
-
-      Autotune.config.google_auth_enabled = tmp
     end
 
     private


### PR DESCRIPTION
We are integrating Autotune with Chorus at Vox Media. However users must first log into Autotune before they can get data out of the API. We want to have a seamless experience that allows any Chorus user to browse and embed available Autotune projects directly from our editor.

This adjustment allows for users to make read only use of the API without having to first visit the site to connect their Google account.