### PR TITLE
Fixes embed copy to clipboard button [lol maybe]

### DIFF
--- a/appjs/views/edit_project.js
+++ b/appjs/views/edit_project.js
@@ -758,9 +758,15 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
   },
 
   copyEmbedToClipboard: function() {
-    this.$("#embed textarea").select();
-    document.execCommand('copy');
-    this.app.view.alert('Embed code copied to clipboard!');
+    // select text from
+    this.$( '#embedText' ).select();
+    try {
+      // copy text
+      document.execCommand( 'copy' );
+      this.app.view.alert( 'Embed code copied to clipboard!' );
+    } catch ( err ) {
+      this.app.view.alert( 'Please press Ctrl/Cmd+C to copy the text.' );
+    }
   },
 
   /**


### PR DESCRIPTION
# What is this change?

Fixes this issue https://github.com/voxmedia/voxmedia-middleman-shared/issues/65. I hope.

`$( '#embed textarea' )` didn't exist so I switched it to `$( '#embedText' )` which does exist. 

I also wrapped it into a try/catch, so that if the button doesn't work it should at least prompt the user to use their keyboard or whatever.

**I tested this in console and it worked, but I have no idea how to test this locally because I can't seem to publish projects locally and since I can't publish I can't get an embed code and thus I can't test and that's where I'm at.** Where are you?
# Why is it being made?

Stuff broke.
# Is this needed to publish a piece? Whats the deadline?

No deadline.
# Is this specific to one vertical, or does it affect everyone?

This affects everything in the universe.
# What are the risks?

The biggest risk is since I can't test this I may have made a typo causing a blocking js error that destroys all the javascript in autotune and the world ends, which is pretty bad imho.
# Gif

![](https://media.giphy.com/media/90gXWXPHXIPFm/giphy.gif)
