### PR TITLE
Theme config data should contain parent theme name

### DIFF
--- a/app/models/autotune/theme.rb
+++ b/app/models/autotune/theme.rb
@@ -65,6 +65,12 @@ module Autotune
       group.name
     end
 
+    # return parent theme name
+    def default_theme
+      return slug if is_default?
+      parent.slug
+    end
+
     # Check if this is a default theme
     def is_default?
       parent.nil?
@@ -81,7 +87,7 @@ module Autotune
       Hash[Theme.all.map { |theme|
              [
                theme.slug,
-               theme.config_data.merge({:group_slug => theme.group.slug})
+               theme.config_data.merge({:group_slug => theme.group.slug, :group_default_theme => theme.default_theme})
              ]
            }]
     end

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autotune",
   "description": "Platform and UI for creating new websites and html snippets from templates stored in git repos.",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "homepage": "https://github.com/voxmedia/autotune",
   "author": {
     "name": "Ryan Mark",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autotune",
   "description": "Platform and UI for creating new websites and html snippets from templates stored in git repos.",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "homepage": "https://github.com/voxmedia/autotune",
   "author": {
     "name": "Ryan Mark",


### PR DESCRIPTION
This PR updates theme config to include name of parent theme. This is required so that blueprints can use shared as the parent theme and just override the required vars