### PR TITLE
Render Autotune in own div

### DIFF
--- a/app/views/layouts/autotune/application.html.erb
+++ b/app/views/layouts/autotune/application.html.erb
@@ -15,7 +15,9 @@
 </head>
 <body>
 <%=render 'autotune/body_top' %>
-<%= yield %>
+<div id="autotune-main-body">
+  <%= yield %>
+</div>
 <%=render 'autotune/body_bottom' %>
 </body>
 </html>

--- a/appjs/app.js
+++ b/appjs/app.js
@@ -91,7 +91,7 @@ function App(config) {
   // Start the app once the top-level view is rendered
   var view = this.view, app = this;
   this.view.render().then(function() {
-    $('body').prepend(view.$el);
+    $('#autotune-main-body').prepend(view.$el);
     app.trigger( 'loadingStart' );
     Backbone.history.start({ pushState: true });
   });


### PR DESCRIPTION
As discussed in #395 we render Autotune in a div in to maintain the order of body_top / Autotune / body_bottom in the layout.