### PR TITLE
Remove jank

### DIFF
--- a/appjs/helpers.js
+++ b/appjs/helpers.js
@@ -4,7 +4,6 @@ var $ = require('jquery'),
     _ = require('underscore'),
     tinycolor = require('tinycolor2'),
     querystring = require('querystring'),
-    escape = require('escape-html'),
     _string = require('underscore.string');
 
 module.exports = {
@@ -59,12 +58,12 @@ module.exports = {
   /**********
    * Theme editor helpers
    */
-   isColor: function(color){
-     return tinycolor(color).isValid();
-   },
+  isColor: function(color){
+    return tinycolor(color).isValid();
+  },
 
   /**********
    * Expose other stuff as helpers
    */
-  escape: escape
+  escape: _string.escapeHTML
 };

--- a/appjs/templates/project.ejs
+++ b/appjs/templates/project.ejs
@@ -26,7 +26,7 @@
   <!-- Tab panes -->
   <div class="tab-content">
     <div role="tabpanel" class="tab-pane active" id="edit">
-      <% if (model.blueprint.hasPreviewType('live')) { %>
+      <% if (model.hasPreviewType('live')) { %>
       <div id="projectEditor" class="row">
 
         <div class="col-md-8 col-sm-7 scroll-pane" id="preview-pane">
@@ -39,7 +39,7 @@
                     class="btn btn-default resize active"></button>
           </ul>
           <br />
-          <p class="blueprint-title"><%= model.blueprint.get('title') %></p>
+          <p class="blueprint-title"><%= model.get('blueprint_title') %></p>
 
           <% if ( model.isNew() ) { %>
             <p> <%= I18n.t('autotune.draft') %> </p>

--- a/appjs/templates/project.ejs
+++ b/appjs/templates/project.ejs
@@ -194,7 +194,7 @@
           <h4> <%= I18n.t('autotune.embed-in-your-story') %> </h4>
 
           <% if ( model.has('embed_html') ) { %>
-          <textarea class="form-control" id="embedText" rows="6" readonly><%=model.get('embed_html') %></textarea>
+          <textarea class="form-control" id="embedText" rows="6" readonly><%=escapeHTML( model.get('embed_html') ) %></textarea>
           <p>
             <button type="button" class="btn btn-default"
                     data-hook="copyEmbedToClipboard"> <%= I18n.t('autotune.copy-embed-code') %> </button>

--- a/appjs/views/application.js
+++ b/appjs/views/application.js
@@ -112,10 +112,14 @@ var Application = BaseView.extend(require('./mixins/links.js'), {
           type: level || 'info',
           delay: 8000,
           before_open: function(thing){
+            logger.debug( 'notification is opening' );
             page.$('#alert-area').parent().addClass('has-alert');
           },
           after_close: function(thing){
-            page.$('#alert-area').parent().removeClass('has-alert');
+            logger.debug( 'notification is closed' );
+            if ( ! page.hasNotifications() ) {
+              page.$('#alert-area').parent().removeClass('has-alert');
+            }
           }
         }, this.alertDefaults);
 
@@ -130,6 +134,10 @@ var Application = BaseView.extend(require('./mixins/links.js'), {
     noti = this.findNotification( message );
 
     return noti || new PNotify(opts);
+  },
+
+  hasNotifications: function() {
+    return PNotify.notices.length > 0;
   },
 
   findNotification: function(message) {

--- a/appjs/views/base_view.js
+++ b/appjs/views/base_view.js
@@ -13,20 +13,6 @@ var $ = require('jquery'),
     h = require("virtual-dom/h"),
     createElement = require('virtual-dom/create-element');
 
-/* Parse HTML into hscript via Promise
- */
-function parseH(string) {
-  return new Promise(function(resolve, reject) {
-    html2hscript(string, function(err, hscript) {
-      if ( err ) {
-        reject(err);
-      } else {
-        resolve(eval('[' + hscript + ']')); // jshint ignore:line
-      }
-    });
-  });
-}
-
 var BaseView = Backbone.View.extend({
   loaded: true,
   firstRender: true,

--- a/appjs/views/base_view.js
+++ b/appjs/views/base_view.js
@@ -4,7 +4,6 @@ var $ = require('jquery'),
     _ = require('underscore'),
     Backbone = require('backbone'),
     camelize = require('underscore.string/camelize'),
-    models = require('../models'),
     logger = require('../logger'),
     helpers = require('../helpers'),
     diff = require('virtual-dom/diff'),
@@ -71,6 +70,8 @@ var BaseView = Backbone.View.extend({
     // into virtual dom nodes
     return new Promise(function(resolve, reject) {
       html2hscript(html, function(err, hscript) {
+        // hscript here is a string of javascript which needs to be evaluated.
+        // The string makes use of the `h` function, which we require above.
         if ( err ) {
           reject(err);
         } else {
@@ -82,9 +83,13 @@ var BaseView = Backbone.View.extend({
     });
   },
 
+  /*
+   * Does the full render process for this view, and populate the view.el
+   * element. Calling this method will update the view without totally
+   * re-rendering it all.
+   */
   render: function() {
-    var scrollPos = $(window).scrollTop(),
-        activeTab = window.location.hash,
+    var activeTab = window.location.hash,
         view = this;
 
     // Only render if this view is loaded
@@ -92,7 +97,6 @@ var BaseView = Backbone.View.extend({
 
     // Do some renderin'. First up: beforeRender()
     return view.hook( 'beforeRender' ).then(function() {
-
       return view.renderVirtualDom();
     }).then(function(virtualEl) {
       var patches = diff(view.virtualEl, virtualEl);
@@ -113,11 +117,6 @@ var BaseView = Backbone.View.extend({
         // Reset first render flag
         logger.debug( 'first render' );
         view.firstRender = false;
-      } else {
-        // Reset scroll position
-        logger.debug('re-render; set scroll',
-                     activeTab, scrollPos, $(document).height());
-        $(window).scrollTop(scrollPos);
       }
 
       view.app.trigger( 'loadingStop' );

--- a/appjs/views/edit_project.js
+++ b/appjs/views/edit_project.js
@@ -113,28 +113,59 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
     this.disableForm = options.disableForm ? true : false;
     this.copyProject = options.copyProject ? true : false;
 
-    window.onbeforeunload = function(event) {
-      if(view.hasUnsavedChanges()){
-        return 'You have unsaved changes!';
-      }
-    };
+    _.bindAll(this, 'onWindowResize');
+
+    // autoselect embed code on focus
+    this.$el.on('focus', 'textarea#embedText', function() { $(this).select(); } );
 
     this.on('load', function() {
+      // Stop listening for changes during loading
       this.listenTo(this.app, 'loadingStart', this.stopListeningForChanges, this);
       this.listenTo(this.app, 'loadingStop', this.listenForChanges, this);
-      $('#navbar-save-container').show();
+
       if ( this.model.hasPreviewType('live') && this.model.getConfig().spreadsheet_template ) {
         // If we have a google spreadsheet, update preview on window focus
         this.listenTo(this.app, 'focus', this.focusPollChange, this);
       }
+
+      // setup warning for closing before saving
+      window.onbeforeunload = function(event) {
+        if(view.hasUnsavedChanges()){
+          return 'You have unsaved changes!';
+        }
+      };
+
+      // window resize handler
+      $(window).on('resize', this.onWindowResize);
+
+      $('#navbar-save-container').show();
     }, this);
 
     this.on('unload', function() {
+      // Remove listers, stop listening for messages
       this.stopListening(this.app);
       this.stopListeningForChanges();
+      window.onbeforeunload = undefined;
+      $(window).off('resize', this.onWindowResize);
+
       $('#navbar-save-container').hide();
+
+      // Remove the pym parent object
       if ( this.pym ) { this.pym.remove(); }
     }, this);
+  },
+
+  onWindowResize: function() {
+    this.showPreviewButtons();
+    if(this.formWidth){
+      if($(window).width() > 768){
+        $('#form-pane').css("width", this.formWidth);
+        $('#preview-pane').css("width", $(window).width() - this.formWidth);
+      } else {
+        $('#form-pane').css("width", '100%');
+        $('#preview-pane').css("width", '100%');
+      }
+    }
   },
 
   askToSave: function() {
@@ -230,11 +261,11 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
       tweetTextControl.setValue($('textarea#shareText').val());
     }
 
-    if(view.postedPreviewData){
+    if ( view.postedPreviewData ) {
       data = view.postedPreviewData;
     }
 
-    if(this.hasUnsavedChanges()){
+    if ( this.hasUnsavedChanges() ) {
       $('.project-save-warning').show().css('display', 'inline-block');
       $('.project-saved').hide();
     } else {
@@ -266,7 +297,7 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
       this.previousData = data;
 
       // Now that data is connected and valid, show some sort of loading indicator:
-      if($('#embed-preview.validation-error')){
+      if ( $('#embed-preview.validation-error') ) {
         $('#embed-preview').removeClass('validation-error').addClass('loading');
       }
 
@@ -283,8 +314,8 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
           $('#embed-preview').removeClass('loading');
         });
 
-        if(data.theme !== view.theme || !view.pym){
-          if(typeof data.theme !== 'undefined'){
+        if ( data.theme !== view.theme || !view.pym ) {
+          if ( typeof data.theme !== 'undefined' ) {
             view.theme = data.theme;
             view.getTwitterCount();
           }
@@ -351,7 +382,9 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
   },
 
   listenForChanges: function() {
+    logger.debug('start listening for changes:', !this.listening);
     if ( !this.model.isNew() && !this.listening ) {
+      logger.debug('start listening for changes');
       this.listenTo(this.app.messages,
                     'change:project:' + this.model.id,
                     this.updateStatus, this);
@@ -360,14 +393,12 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
   },
 
   stopListeningForChanges: function() {
+    logger.debug('stop listening for changes');
     this.stopListening(this.app.messages);
     this.listening = false;
   },
 
   updateStatus: function(status) {
-    // don't care about the updated step
-    if ( status === 'updated' ) { return; }
-
     logger.debug('Update project status: ' + status);
     if (status === 'built'){
       if(!this.model.hasPreviewType('live')){
@@ -383,7 +414,7 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
       .then(function() {
         return view.render();
       }).catch(function(jqXHR) {
-        view.app.view.displayError(
+        view.parentView.displayError(
           jqXHR.status, jqXHR.statusText, jqXHR.responseText);
       });
   },
@@ -408,107 +439,34 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
   },
 
   afterRender: function() {
-    var view = this, promises = [];
+    logger.debug('in after render');
+    var view = this;
 
     view.enableFormSlide = false;
     view.showPreviewButtons();
-    $(window).resize(function(){
-      view.showPreviewButtons();
-      if(view.formWidth){
-        if($(window).width() > 768){
-          $('#form-pane').css("width", view.formWidth);
-          $('#preview-pane').css("width", $(window).width() - view.formWidth);
-        } else {
-          $('#form-pane').css("width", '100%');
-          $('#preview-pane').css("width", '100%');
-        }
-      }
-    });
-
-    // autoselect embed code on focus
-    this.$("#embed textarea").focus( function() { $(this).select(); } );
 
     // Setup editor for data field
     if ( this.app.hasRole('superuser') ) {
-      this.editor = ace.edit('blueprint-data');
-      this.editor.setShowPrintMargin(false);
-      this.editor.setTheme("ace/theme/textmate");
-      this.editor.setWrapBehavioursEnabled(true);
+      if ( !this.editor ) {
+        this.editor = ace.edit('blueprint-data');
+        this.editor.setShowPrintMargin(false);
+        this.editor.setTheme("ace/theme/textmate");
+        this.editor.setWrapBehavioursEnabled(true);
 
-      var session = this.editor.getSession();
-      session.setMode("ace/mode/json");
-      session.setUseWrapMode(true);
+        var session = this.editor.getSession();
+        session.setMode("ace/mode/json");
+        session.setUseWrapMode(true);
 
-      this.editor.renderer.setHScrollBarAlwaysVisible(false);
-
+        this.editor.renderer.setHScrollBarAlwaysVisible(false);
+      }
       this.editor.setValue(
-        JSON.stringify( this.model.buildData(), null, "  " ), -1 );
-
-      var debouncedStopListeningForChanges = _.once(
-        _.bind(this.stopListeningForChanges, this));
-      this.editor.on("change", function() {
-        logger.debug('editor content changed');
-        debouncedStopListeningForChanges();
-      });
+        JSON.stringify( this.model.formData(), null, "  " ), -1 );
     }
 
-    promises.push( new Promise( function(resolve, reject) {
-      view.renderForm(resolve, reject);
-    } ) );
-
-    return Promise.all(promises)
-      .then(function() {
-        var formData = view.alpaca.getValue(),
-            buildData = view.model.buildData(),
-            previewUrl = '', iframeLoaded,
-            previewSlug = '';
-
-        view.$('#shareText').val(formData['tweet_text']);
-        view.formDataOnLoad = formData;
-
-        // Callback for when iframe loads
-        iframeLoaded = _.once(function() {
-          logger.debug('iframeLoaded');
-          if ( view.model.hasPreviewType('live') && view.model.hasBuildData() ) {
-            view.pollChange();
-          } else {
-            if(!view.model.hasStatus('building')){
-              $('#embed-preview').removeClass('loading');
-            }
-          }
-        });
-
-        // Figure out preview url
-        if ( view.model.hasPreviewType('live') ) {
-          // if the project has live preview enabled
-          view.theme = view.model.get('theme') || formData['theme'] || 'custom';
-
-          previewSlug = view.model.isThemeable() ? view.model.getVersion() :
-            [view.model.getVersion(), view.theme].join('-');
-          previewUrl = view.model.blueprint.getMediaUrl( previewSlug + '/preview');
-
-        } else if ( view.model.hasType( 'graphic' ) && view.model.hasInitialBuild() ){
-          // if the project is a graphic and has been built (but doesn't have live enabled)
-          var previousPreviewUrl = view.model['_previousAttributes']['preview_url'];
-
-          if(previousPreviewUrl && previousPreviewUrl !==  view.model.get('preview_url')){
-            previewUrl = previousPreviewUrl;
-          } else {
-            previewUrl = view.model.get('preview_url');
-          }
-        }
-
-        if ( view.model.hasType( 'graphic' ) || view.model.hasPreviewType('live') ) {
-          // Setup our iframe with pym
-          if ( view.pym ) { view.pym.remove(); }
-          if ( view.formValidate(view.model, view.$('#projectForm')) ){
-            view.pym = new pym.Parent('embed-preview', previewUrl);
-            view.pym.iframe.onload = iframeLoaded;
-          }
-          // In case some dumb script hangs the loading process
-          setTimeout(iframeLoaded, 20000);
-        }
-
+    return new Promise(function(resolve, reject) {
+        view.renderForm(resolve, reject);
+      }).then(function() {
+        view.renderPreview();
         view.getTwitterCount();
       }).catch(function(err) {
         console.error(err);
@@ -528,6 +486,63 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
     }
   },
 
+  renderPreview: function() {
+    var formData = this.alpaca.getValue(),
+      buildData = this.model.buildData(),
+      previewUrl = '', iframeLoaded,
+      previewSlug = '';
+
+    // Preview is already rendered
+    if ( this.pym && this.pym.iframe.parentElement ) { return; }
+
+    this.$('#shareText').val(formData['tweet_text']);
+    this.formDataOnLoad = formData;
+
+    // Callback for when iframe loads
+    var view = this;
+    iframeLoaded = _.once(function() {
+      logger.debug('iframeLoaded');
+      if ( view.model.hasPreviewType('live') && view.model.hasBuildData() ) {
+        view.pollChange();
+      } else {
+        if(!view.model.hasStatus('building')){
+          $('#embed-preview').removeClass('loading');
+        }
+      }
+    });
+
+    // Figure out preview url
+    if ( this.model.hasPreviewType('live') ) {
+      // if the project has live preview enabled
+      this.theme = this.model.get('theme') || formData['theme'] || 'custom';
+
+      previewSlug = this.model.isThemeable() ? this.model.getVersion() :
+        [this.model.getVersion(), this.theme].join('-');
+      previewUrl = this.model.blueprint.getMediaUrl( previewSlug + '/preview');
+
+    } else if ( this.model.hasType( 'graphic' ) && this.model.hasInitialBuild() ){
+      // if the project is a graphic and has been built (but doesn't have live enabled)
+      var previousPreviewUrl = this.model['_previousAttributes']['preview_url'];
+
+      if ( previousPreviewUrl && previousPreviewUrl !== this.model.get('preview_url') ){
+        previewUrl = previousPreviewUrl;
+      } else {
+        previewUrl = this.model.get('preview_url');
+      }
+    }
+
+    if ( this.model.hasType( 'graphic' ) || this.model.hasPreviewType('live') ) {
+      // Setup our iframe with pym
+      if ( this.pym ) { this.pym.remove(); }
+      if ( this.formValidate(this.model, this.$('#projectForm')) ){
+        this.pym = new pym.Parent('embed-preview', previewUrl);
+        this.pym.iframe.onload = iframeLoaded;
+      }
+      // In case some dumb script hangs the loading process
+      setTimeout(iframeLoaded, 20000);
+    }
+  },
+
   renderForm: function(resolve, reject) {
     var $form = this.$('#projectForm'),
         view = this,
@@ -538,6 +553,9 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
         '<div class="alert alert-warning" role="alert">Form is disabled</div>');
       return resolve();
     }
+
+    // Alpaca form is already setup
+    if ( $form.alpaca('get') ) { resolve(); }
 
     // Prevent return or enter from submitting the form
     $form.keypress(function(event){
@@ -551,6 +569,11 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
 
     form_config = this.model.getConfig().form;
 
+    if ( _.isUndefined(form_config) ) {
+      this.app.view.error('This blueprint does not have a form!', true);
+      return reject('This blueprint does not have a form!');
+    }
+
     availableThemes = this.model.getConfig().themes ?
       _.filter(this.app.themes.models, _.bind(function(t) {
         return _.contains(this.model.getConfig().themes, t.get('slug'));
@@ -558,154 +581,143 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
     availableThemes = availableThemes || this.app.themes.where({slug : 'generic'});
     this.twitterHandles = _.object(this.app.themes.pluck('slug'), this.app.themes.pluck('twitter_handle'));
 
-    if(_.isUndefined(form_config)) {
-      this.app.view.error('This blueprint does not have a form!', true);
-      reject('This blueprint does not have a form!');
-    } else {
-      var schema_properties = {
-        "title": {
-          "title": "Title",
-          "type": "string",
-          "required": true
-        },
-        "theme": {
-          "title": "Theme",
-          "type": "string",
-          "required": true,
-          "default": pluckAttr(availableThemes, 'slug')[0],
-          "enum": pluckAttr(availableThemes, 'slug')
-        },
-        "slug": {
-          "title": "Slug",
-          "type": "string"
-        },
-        "tweet_text":{
-          "type": "string",
-          "minLength": 0
-        }
+    var schema_properties = {
+      "title": {
+        "title": "Title",
+        "type": "string",
+        "required": true
       },
-      options_form = {
-        "attributes": {
-          "data-model": "Project",
-          "data-model-id": this.model.isNew() ? '' : this.model.id,
-          "data-action": this.model.isNew() ? 'new' : 'edit',
-          "data-next": 'show',
-          "method": 'post'
-        }
+      "theme": {
+        "title": "Theme",
+        "type": "string",
+        "required": true,
+        "default": pluckAttr(availableThemes, 'slug')[0],
+        "enum": pluckAttr(availableThemes, 'slug')
       },
-      options_fields = {
-        "theme": {
-          "type": "select",
-          "optionLabels": _.map(availableThemes, function(t){
-               if (t.get('title') === t.get('group_name')) {
-                 return t.get('group_name');
-               }
-               return t.get('group_name') + ' - ' + t.get('title');
-             })
-        },
-        "slug": {
-          "label": "Slug",
-          "validator": function(callback){
-            var slugPattern = /^[0-9a-z\-_]{0,60}$/;
-            var slug = this.getValue();
-            if ( slugPattern.test(slug) ){
-              callback({ "status": true });
-            } else if (slugPattern.test(slug.substring(0,60))){
-              this.setValue(slug.substr(0,60));
-              callback({ "status": true });
-            } else {
-              callback({
-                "status": false,
-                "message": "Must contain fewer than 60 numbers, lowercase letters, hyphens, and underscores."
-              });
-            }
+      "slug": {
+        "title": "Slug",
+        "type": "string"
+      },
+      "tweet_text":{
+        "type": "string",
+        "minLength": 0
+      }
+    },
+    options_form = {
+      "attributes": {
+        "data-model": "Project",
+        "data-model-id": this.model.isNew() ? '' : this.model.id,
+        "data-action": this.model.isNew() ? 'new' : 'edit',
+        "data-next": 'show',
+        "method": 'post'
+      }
+    },
+    options_fields = {
+      "theme": {
+        "type": "select",
+        "optionLabels": _.map(availableThemes, function(t){
+             if (t.get('title') === t.get('group_name')) {
+               return t.get('group_name');
+             }
+             return t.get('group_name') + ' - ' + t.get('title');
+           })
+      },
+      "slug": {
+        "label": "Slug",
+        "validator": function(callback){
+          var slugPattern = /^[0-9a-z\-_]{0,60}$/;
+          var slug = this.getValue();
+          if ( slugPattern.test(slug) ){
+            callback({ "status": true });
+          } else if (slugPattern.test(slug.substring(0,60))){
+            this.setValue(slug.substr(0,60));
+            callback({ "status": true });
+          } else {
+            callback({
+              "status": false,
+              "message": "Must contain fewer than 60 numbers, lowercase letters, hyphens, and underscores."
+            });
           }
-        },
-        "tweet_text":{
-          "label": "Social share text",
-          "constrainMaxLength": true,
-          "constrainMinLength": true,
-          "showMaxLengthIndicator": true,
-          "fieldClass": "hidden"
         }
-      };
-
-      // if there is only one theme option, hide the dropdown
-
-      // Temporarily disabling theme drop down hiding to fix custom color bug
-      //if ( availableThemes.length === 1 ) {
-      //  options_fields['theme']['fieldClass'] = 'hidden';
-      //}
-
-      // hide slug for blueprint types that are not apps
-      if ( !_.contains(this.app.config.editable_slug_types, this.model.blueprint.get('type') ) ) {
-        options_fields['slug']['fieldClass'] = 'hidden';
+      },
+      "tweet_text":{
+        "label": "Social share text",
+        "constrainMaxLength": true,
+        "constrainMinLength": true,
+        "showMaxLengthIndicator": true,
+        "fieldClass": "hidden"
       }
+    };
 
-      _.extend(schema_properties, form_config.schema.properties || {});
-      if( form_config.options ) {
-        _.extend(options_form, form_config.options.form || {});
-        _.extend(options_fields, form_config.options.fields || {});
-      }
+    // if there is only one theme option, hide the dropdown
 
-      // This monkey-patches the config for google_doc_url fields to use the googledoc field control
-      if ( options_fields.google_doc_url && options_fields.google_doc_url.type === 'url' ) {
-        options_fields.google_doc_url.type = 'googledoc';
-        if ( this.model.getConfig().spreadsheet_template ) {
-          options_fields.google_doc_url.doc_template_url = this.model.getConfig().spreadsheet_template;
-        }
-      }
+    // Temporarily disabling theme drop down hiding to fix custom color bug
+    //if ( availableThemes.length === 1 ) {
+    //  options_fields['theme']['fieldClass'] = 'hidden';
+    //}
 
-      var opts = {
-        "schema": {
-          "title": function(){
-            if(view.model.hasPreviewType('live')){
-              return '';
-            } else {
-              return view.model.blueprint.get('title');
-            }
-          },
-          "description": this.model.getConfig().description,
-          "type": "object",
-          "properties": schema_properties
-        },
-        "options": {
-          "form": options_form,
-          "fields": options_fields,
-          "focus": this.firstRender
-        },
-        "postRender": function(control) {
-          view.alpaca = control;
-
-          view.alpaca.childrenByPropertyId["slug"].setValue(
-            view.model.get('slug_sans_theme') );
-
-          resolve();
-        }
-      };
-
-      if( form_config['view'] ) {
-        opts.view = form_config.view;
-      }
-
-      if(!this.model.isNew() || this.copyProject) {
-        populateForm = true;
-      } else if (this.model.isNew() && !this.copyProject && !this.model.hasInitialBuild()){
-        var uniqBuildVals = _.uniq(_.values(this.model.buildData()));
-        if (!( uniqBuildVals.length === 1 && typeof(uniqBuildVals[0]) === 'undefined')){
-          populateForm = true;
-        }
-      }
-
-      if(populateForm){
-        opts.data = this.model.formData();
-        if ( !_.contains(pluckAttr(availableThemes, 'slug'), opts.data.theme) ) {
-          opts.data.theme = pluckAttr(availableThemes, 'slug')[0];
-        }
-      }
-
-      $form.alpaca(opts);
+    // hide slug for blueprint types that are not apps
+    if ( !_.contains(this.app.config.editable_slug_types, this.model.blueprint.get('type') ) ) {
+      options_fields['slug']['fieldClass'] = 'hidden';
     }
+
+    _.extend(schema_properties, form_config.schema.properties || {});
+    if( form_config.options ) {
+      _.extend(options_form, form_config.options.form || {});
+      _.extend(options_fields, form_config.options.fields || {});
+    }
+
+    // This monkey-patches the config for google_doc_url fields to use the googledoc field control
+    if ( options_fields.google_doc_url && options_fields.google_doc_url.type === 'url' ) {
+      options_fields.google_doc_url.type = 'googledoc';
+      if ( this.model.getConfig().spreadsheet_template ) {
+        options_fields.google_doc_url.doc_template_url = this.model.getConfig().spreadsheet_template;
+      }
+    }
+
+    var opts = {
+      "schema": {
+        "title": this.model.hasPreviewType('live') ? '' : this.model.getConfig().title,
+        "description": this.model.getConfig().description,
+        "type": "object",
+        "properties": schema_properties
+      },
+      "options": {
+        "form": options_form,
+        "fields": options_fields,
+        "focus": this.firstRender
+      },
+      "postRender": function(control) {
+        view.alpaca = control;
+
+        view.alpaca.childrenByPropertyId["slug"].setValue(
+          view.model.get('slug_sans_theme') );
+
+        resolve();
+      }
+    };
+
+    if( form_config['view'] ) {
+      opts.view = form_config.view;
+    }
+
+    if(!this.model.isNew() || this.copyProject) {
+      populateForm = true;
+    } else if (this.model.isNew() && !this.copyProject && !this.model.hasInitialBuild()){
+      var uniqBuildVals = _.uniq(_.values(this.model.buildData()));
+      if (!( uniqBuildVals.length === 1 && typeof(uniqBuildVals[0]) === 'undefined')){
+        populateForm = true;
+      }
+    }
+
+    if(populateForm){
+      opts.data = this.model.formData();
+      if ( !_.contains(pluckAttr(availableThemes, 'slug'), opts.data.theme) ) {
+        opts.data.theme = pluckAttr(availableThemes, 'slug')[0];
+      }
+    }
+
+    $form.alpaca(opts);
   },
 
   formValues: function($form) {

--- a/appjs/views/edit_project.js
+++ b/appjs/views/edit_project.js
@@ -125,7 +125,7 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
 
       if ( this.model.hasPreviewType('live') && this.model.getConfig().spreadsheet_template ) {
         // If we have a google spreadsheet, update preview on window focus
-        this.listenTo(this.app, 'focus', this.focusPollChange, this);
+        this.listenTo(this.app, 'focus', this.onAppFocus, this);
       }
 
       // setup warning for closing before saving
@@ -145,7 +145,7 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
       // Remove listers, stop listening for messages
       this.stopListening(this.app);
       this.stopListeningForChanges();
-      window.onbeforeunload = undefined;
+      delete window.onbeforeunload;
       $(window).off('resize', this.onWindowResize);
 
       $('#navbar-save-container').hide();
@@ -245,8 +245,9 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
     return false;
   },
 
-  focusPollChange: function(){
+  onAppFocus: function(){
     this.forceUpdateDataFlag = true;
+    this.showPreviewButtons();
     this.pollChange();
   },
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "autotune",
-  "version": "0.4.20",
+  "version": "0.5.3",
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -396,6 +396,11 @@
         }
       }
     },
+    "browser-split": {
+      "version": "0.0.1",
+      "from": "browser-split@0.0.1",
+      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.1.tgz"
+    },
     "browserify": {
       "version": "5.12.1",
       "from": "browserify@5.12.1",
@@ -517,6 +522,11 @@
           "dev": true
         }
       }
+    },
+    "camelize": {
+      "version": "1.0.0",
+      "from": "camelize@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz"
     },
     "cardinal": {
       "version": "0.4.4",
@@ -851,27 +861,23 @@
       "version": "0.1.0",
       "from": "dom-serializer@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
           "from": "domelementtype@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
         },
         "entities": {
           "version": "1.1.1",
           "from": "entities@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
         }
       }
     },
     "dom-walk": {
       "version": "0.1.1",
       "from": "dom-walk@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz"
     },
     "domain-browser": {
       "version": "1.1.7",
@@ -881,20 +887,17 @@
     "domelementtype": {
       "version": "1.3.0",
       "from": "domelementtype@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
     },
     "domhandler": {
       "version": "2.3.0",
       "from": "domhandler@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
     },
     "domutils": {
       "version": "1.5.1",
       "from": "domutils@>=1.5.0 <1.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
     },
     "duplexer": {
       "version": "0.1.1",
@@ -924,11 +927,15 @@
       "resolved": "https://registry.npmjs.org/enstore/-/enstore-1.0.1.tgz",
       "dev": true
     },
+    "ent": {
+      "version": "2.2.0",
+      "from": "ent@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz"
+    },
     "entities": {
       "version": "1.0.0",
       "from": "entities@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
     },
     "eonasdan-bootstrap-datetimepicker": {
       "version": "4.15.35",
@@ -939,6 +946,18 @@
           "version": "2.8.4",
           "from": "moment@>=2.8.0 <2.9.0",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
+        }
+      }
+    },
+    "error": {
+      "version": "4.4.0",
+      "from": "error@>=4.3.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/error/-/error-4.4.0.tgz",
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.1",
+          "from": "xtend@>=4.0.0 <4.1.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
@@ -1002,6 +1021,11 @@
       "version": "1.0.0",
       "from": "esutils@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+    },
+    "ev-store": {
+      "version": "7.0.0",
+      "from": "ev-store@>=7.0.0 <8.0.0",
+      "resolved": "https://registry.npmjs.org/ev-store/-/ev-store-7.0.0.tgz"
     },
     "eventemitter2": {
       "version": "0.4.14",
@@ -2166,13 +2190,11 @@
       "version": "4.3.0",
       "from": "global@>=4.3.0 <4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.0.tgz",
-      "dev": true,
       "dependencies": {
         "process": {
           "version": "0.5.2",
           "from": "process@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
         }
       }
     },
@@ -2529,6 +2551,11 @@
         }
       }
     },
+    "html2hscript": {
+      "version": "2.0.1",
+      "from": "html2hscript@latest",
+      "resolved": "https://registry.npmjs.org/html2hscript/-/html2hscript-2.0.1.tgz"
+    },
     "htmlescape": {
       "version": "1.1.1",
       "from": "htmlescape@>=1.1.0 <2.0.0",
@@ -2538,8 +2565,7 @@
     "htmlparser2": {
       "version": "3.8.3",
       "from": "htmlparser2@>=3.8.0 <3.9.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz"
     },
     "http-browserify": {
       "version": "1.7.0",
@@ -2589,6 +2615,11 @@
       "version": "0.0.1",
       "from": "indexof@0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+    },
+    "individual": {
+      "version": "3.0.0",
+      "from": "individual@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz"
     },
     "inflight": {
       "version": "1.0.5",
@@ -2706,6 +2737,11 @@
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
       "dev": true
     },
+    "is-empty": {
+      "version": "0.0.1",
+      "from": "is-empty@0.0.1",
+      "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-0.0.1.tgz"
+    },
     "is-equal-shallow": {
       "version": "0.1.3",
       "from": "is-equal-shallow@>=0.1.3 <0.2.0",
@@ -2767,6 +2803,11 @@
       "from": "is-number@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "dev": true
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "from": "is-object@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz"
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -3224,8 +3265,7 @@
     "min-document": {
       "version": "2.18.0",
       "from": "min-document@>=2.6.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.18.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.18.0.tgz"
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -3330,6 +3370,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
       "dev": true,
       "optional": true
+    },
+    "next-tick": {
+      "version": "0.2.2",
+      "from": "next-tick@>=0.2.2 <0.3.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
     },
     "node-underscorify": {
       "version": "0.0.14",
@@ -4194,6 +4239,11 @@
       "from": "string_decoder@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz"
     },
+    "string-template": {
+      "version": "0.2.1",
+      "from": "string-template@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
+    },
     "string-width": {
       "version": "1.0.2",
       "from": "string-width@>=1.0.1 <2.0.0",
@@ -4457,6 +4507,21 @@
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "dev": true
     },
+    "to-camel-case": {
+      "version": "0.2.1",
+      "from": "to-camel-case@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-0.2.1.tgz"
+    },
+    "to-no-case": {
+      "version": "0.1.1",
+      "from": "to-no-case@0.1.1",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-0.1.1.tgz"
+    },
+    "to-space-case": {
+      "version": "0.1.2",
+      "from": "to-space-case@0.1.2",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-0.1.2.tgz"
+    },
     "tough-cookie": {
       "version": "2.2.2",
       "from": "tough-cookie@>=2.2.0 <2.3.0",
@@ -4642,6 +4707,11 @@
       "from": "verror@1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "dev": true
+    },
+    "virtual-dom": {
+      "version": "2.1.1",
+      "from": "virtual-dom@latest",
+      "resolved": "https://registry.npmjs.org/virtual-dom/-/virtual-dom-2.1.1.tgz"
     },
     "vm-browserify": {
       "version": "0.0.4",
@@ -4985,6 +5055,16 @@
       "version": "1.0.2",
       "from": "wrappy@1",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+    },
+    "x-is-array": {
+      "version": "0.1.0",
+      "from": "x-is-array@0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-array/-/x-is-array-0.1.0.tgz"
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "from": "x-is-string@0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz"
     },
     "xhr-write-stream": {
       "version": "0.1.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -985,11 +985,6 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
       "dev": true
     },
-    "escape-html": {
-      "version": "1.0.3",
-      "from": "escape-html@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "from": "escape-string-regexp@>=1.0.2 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "browserify": "5.12.1",
     "browserify-shim": "3.8.0",
     "eonasdan-bootstrap-datetimepicker": "^4.15.35",
-    "escape-html": "^1.0.3",
     "handlebars": "4.0.5",
     "html2hscript": "^2.0.1",
     "jquery": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eonasdan-bootstrap-datetimepicker": "^4.15.35",
     "escape-html": "^1.0.3",
     "handlebars": "4.0.5",
+    "html2hscript": "^2.0.1",
     "jquery": "2.1.1",
     "jquery-ui": "1.10.5",
     "markdown": "0.5.0",
@@ -53,7 +54,8 @@
     "spectrum-colorpicker": "bgrins/spectrum",
     "tinycolor2": "^1.3.0",
     "underscore": "1.8.3",
-    "underscore.string": "3.0.3"
+    "underscore.string": "3.0.3",
+    "virtual-dom": "^2.1.1"
   },
   "devDependencies": {
     "browser-run": ">=2.6.2",


### PR DESCRIPTION
This PR fixes a lot of the jumping around and redrawing of the page when saving, publishing and rebuilding projects in autotune and fixes notifications occasionally overlapping the header.

Lots of visual bugfixes to the UI:
- Views are now re-rendered using virtual dom, so instead of redrawing the entire page, we're applying a patch to change affected parts.
- The app now checks to see if there are any displayed notifications before moving the header back up into place.
- App no longer saves and updates scroll position between renders, because its no longer necessary.
- The project edit view no longer recreates the alpaca form, pym preview and json editor on every page refresh, making it much faster.
- Fix bug which prevents project page from rendering for bespoke projects.