### PR TITLE
Add Jenkins testing and Gemnasium monitoring

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,27 @@
+#!/usr/bin/env groovy
+
+properties(defaultVars.projectProperties)
+
+node {
+  checkout scm
+
+  stage('Test') {
+    try {
+      cancelBuildsOfSameJob()
+      notifyBuild('STARTED', '#app-log-autotune')
+      ansiColor('xterm') {
+        withVoxOpsSSHKeyPath {
+          sh "./bin/test_docker_build.sh"
+          if (env.BRANCH_NAME == 'master') {
+            pushGemnasiumUpdate()
+          }
+        }
+      }
+    } catch (e) {
+      currentBuild.result = "FAILED"
+      throw e
+    } finally {
+      notifyBuild(currentBuild.result, '#app-log-autotune')
+    }
+  }
+}

--- a/bin/test_run.sh
+++ b/bin/test_run.sh
@@ -5,8 +5,12 @@ rm -Rf Gemfile.lock .bundle
 bundle install --path vendor/bundle --no-deployment --no-color
 
 export RAILS_ENV=test
-bundle exec rake db:reset 
+bundle exec rake db:reset
 bundle exec rake test
+
+# TODO: should we also do these?
+#   npm install
+#   npm test
 
 rm -f ./log/*.log
 rm -rf ./working


### PR DESCRIPTION
# What does this do?

Previously autotune had been tested by Jenkins. But with the move to Jenkins 2.0 it got left behind. This PR:

* adds it back into Jenkins' list of tested projects
* adds automated Gemnasium vulnerability analysis

In addition to this PR, I've verified the Gemnasium project slug is correct, and added autotune into the Jenkins project-name regex.

# More eyes wanted, please

Can someone who knows more about `node` than I do please see if [these lines](https://github.com/voxmedia/autotune/compare/systems-push-gemnasium-update?expand=1#diff-d743e540ff708c5f462eaf6a389d1f5cR11) would make sense? And if so, uncomment them.

The Jenkinsfile here was basically copied from anthem, and I checked `bin/test_docker_build.sh` by eye, so I don't have any reason to think they won't work. But I'm not a Jenkins expert.

# Deploy

Merging will suffice, no deploy is actually necessary (though shouldn't hurt of course).

Jenkins scans all `voxmedia` repositories periodically to determine which should appear in the Vox Media list. Until this merges, `autotune` won't appear, because it's missing a `Jenkinsfile`. After this merges, I think you can wait a few hours and then check the console to see if an automatic scan picked it up -- or I think you can open the configure page and probably just click Save to trigger an immediate scan.