### PR TITLE
Turn off screenshots for bespoke projects

### DIFF
--- a/app/jobs/autotune/build_job.rb
+++ b/app/jobs/autotune/build_job.rb
@@ -54,7 +54,7 @@ module Autotune
       deployer.deploy(project.full_deploy_dir)
 
       # Create screenshots (has to happen after upload)
-      if repo.command?('phantomjs') && !Rails.env.test?
+      if repo.command?('phantomjs') && !Rails.env.test? && !project.bespoke
         begin
           url = deployer.url_for('/')
           script_path = Autotune.root.join('bin', 'screenshot.js').to_s

--- a/app/jobs/autotune/build_job.rb
+++ b/app/jobs/autotune/build_job.rb
@@ -54,7 +54,8 @@ module Autotune
       deployer.deploy(project.full_deploy_dir)
 
       # Create screenshots (has to happen after upload)
-      if repo.command?('phantomjs') && !Rails.env.test? && !project.bespoke
+      if repo.command?('phantomjs') && !Rails.env.test? && build_data['screenshot']
+        p 'screenshot fired'
         begin
           url = deployer.url_for('/')
           script_path = Autotune.root.join('bin', 'screenshot.js').to_s

--- a/lib/autotune/deployer.rb
+++ b/lib/autotune/deployer.rb
@@ -27,8 +27,7 @@ module Autotune
 
     # Hook for adjusting data and files before build
     def before_build(build_data, _env, current_user = nil)
-
-      if build_data['google_doc_url'] && current_user
+      if build_data['google_doc_url'].present? && current_user
         current_auth = current_user.authorizations.find_by!(:provider => 'google_oauth2')
         if current_auth.present?
           google_client = GoogleDocs.new(
@@ -42,24 +41,26 @@ module Autotune
           current_auth.save!
 
           doc_key = GoogleDocs.key_from_url(build_data['google_doc_url'])
-          resp = google_client.find(doc_key)
-          cache_key = "googledoc#{doc_key}"
+          if doc_key.present?
+            resp = google_client.find(doc_key)
+            cache_key = "googledoc#{doc_key}"
 
-          if Rails.cache.exist?(cache_key)
-            cache_value = Rails.cache.read(cache_key)
-            needs_update = cache_value['version'] && resp['version'] != cache_value['version']
-          else
-            needs_update = true
-          end
+            if Rails.cache.exist?(cache_key)
+              cache_value = Rails.cache.read(cache_key)
+              needs_update = cache_value['version'] && resp['version'] != cache_value['version']
+            else
+              needs_update = true
+            end
 
-          if needs_update
-            google_client.share_with_domain(
-              doc_key, Autotune.configuration.google_auth_domain)
-            ss_data = google_client.get_doc_contents(build_data['google_doc_url'])
-            build_data['google_doc_data'] = ss_data
-            Rails.cache.write(cache_key, 'ss_data' => ss_data, 'version' => resp['version'])
-          else
-            build_data['google_doc_data'] = Rails.cache.read(cache_key)['ss_data']
+            if needs_update
+              google_client.share_with_domain(
+                doc_key, Autotune.configuration.google_auth_domain)
+              ss_data = google_client.get_doc_contents(build_data['google_doc_url'])
+              build_data['google_doc_data'] = ss_data
+              Rails.cache.write(cache_key, 'ss_data' => ss_data, 'version' => resp['version'])
+            else
+              build_data['google_doc_data'] = Rails.cache.read(cache_key)['ss_data']
+            end
           end
         end
       end

--- a/lib/autotune/deployer.rb
+++ b/lib/autotune/deployer.rb
@@ -27,6 +27,7 @@ module Autotune
 
     # Hook for adjusting data and files before build
     def before_build(build_data, _env, current_user = nil)
+
       if build_data['google_doc_url'] && current_user
         current_auth = current_user.authorizations.find_by!(:provider => 'google_oauth2')
         if current_auth.present?
@@ -69,6 +70,7 @@ module Autotune
       build_data['theme_data'] = Theme.full_theme_data unless build_data['theme_data'].present?
       build_data['group'] = project.group.slug if project.respond_to?(:group) && project.group
       build_data['theme'] = project.theme.slug if project.respond_to?(:theme) && project.theme
+      build_data['screenshot'] = true unless build_data['screenshot'].present?
 
       build_data['base_url'] = project_url
       build_data['asset_base_url'] = project_asset_url

--- a/lib/autotune/google_docs.rb
+++ b/lib/autotune/google_docs.rb
@@ -236,18 +236,38 @@ module Autotune
       data = {}
       xls.worksheets.each do |sheet|
         title = sheet.sheet_name
+        sheet_data = extract_data(sheet)
+
         # if the sheet is called microcopy, copy or ends with copy, we assume
         # the first column contains keys and the second contains values.
         # Like tarbell.
         if %w(microcopy copy).include?(title.downcase) ||
            title.downcase =~ /[ -_]copy$/
-          data[title] = load_microcopy(sheet.extract_data)
+          data[title] = load_microcopy(sheet_data)
         else
           # otherwise parse the sheet into a hash
-          data[title] = load_table(sheet.extract_data)
+          data[title] = load_table(sheet_data)
         end
       end
       data
+    end
+
+    # Extract the data from a spreadsheet
+    # Takes the spreadsheet object and returns the table data as an array
+    #
+    # @param sheet [Object] the spreadsheet object
+    # @return [Array] spreadsheet contents
+    def extract_data(sheet)
+      data = []
+      sheet.each do |row|
+        data_row = []
+        row && row.cells.each do |cell|
+          data_cell = cell && cell.value
+          data_row << data_cell
+        end
+        data << data_row
+      end
+      return data
     end
 
     # Take a two-dimensional array from a spreadsheet and create a hash. The first

--- a/lib/autotune/google_docs.rb
+++ b/lib/autotune/google_docs.rb
@@ -17,7 +17,8 @@ module Autotune
     end
 
     def self.key_from_url(url)
-      parse_url(url)['id']
+      match = parse_url(url)
+      match.nil? ? nil : match['id']
     end
 
     def auth
@@ -236,38 +237,18 @@ module Autotune
       data = {}
       xls.worksheets.each do |sheet|
         title = sheet.sheet_name
-        sheet_data = extract_data(sheet)
-
         # if the sheet is called microcopy, copy or ends with copy, we assume
         # the first column contains keys and the second contains values.
         # Like tarbell.
         if %w(microcopy copy).include?(title.downcase) ||
            title.downcase =~ /[ -_]copy$/
-          data[title] = load_microcopy(sheet_data)
+          data[title] = load_microcopy(sheet.extract_data)
         else
           # otherwise parse the sheet into a hash
-          data[title] = load_table(sheet_data)
+          data[title] = load_table(sheet.extract_data)
         end
       end
       data
-    end
-
-    # Extract the data from a spreadsheet
-    # Takes the spreadsheet object and returns the table data as an array
-    #
-    # @param sheet [Object] the spreadsheet object
-    # @return [Array] spreadsheet contents
-    def extract_data(sheet)
-      data = []
-      sheet.each do |row|
-        data_row = []
-        row && row.cells.each do |cell|
-          data_cell = cell && cell.value
-          data_row << data_cell
-        end
-        data << data_row
-      end
-      return data
     end
 
     # Take a two-dimensional array from a spreadsheet and create a hash. The first


### PR DESCRIPTION
Screenshots don't work for bespoke projects. Not sure if this is something that is ever really a need, but this turns them off for now to stop errors from piling up.