### PR TITLE
Deployer take_screenshot? method

### DIFF
--- a/app/jobs/autotune/build_job.rb
+++ b/app/jobs/autotune/build_job.rb
@@ -54,7 +54,7 @@ module Autotune
       deployer.deploy(project.full_deploy_dir)
 
       # Create screenshots (has to happen after upload)
-      if repo.command?('phantomjs') && !Rails.env.test?
+      if deployer.take_screenshots?
         begin
           url = deployer.url_for('/')
           script_path = Autotune.root.join('bin', 'screenshot.js').to_s

--- a/lib/autotune/deployer.rb
+++ b/lib/autotune/deployer.rb
@@ -135,6 +135,10 @@ module Autotune
       [try(:asset_base_url) || base_url, project.slug, extra_slug].reject(&:blank?).join('/')
     end
 
+    def take_screenshots?
+      repo.command?('phantomjs') && !Rails.env.test?
+    end
+
     def logger
       @logger ||= Rails.logger
     end


### PR DESCRIPTION
Allow deployer object to decide if screenshots can and should be taken.