### PR TITLE
Change omniauth dependency to ~> 1.3

### DIFF
--- a/autotune.gemspec
+++ b/autotune.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'rails', '~> 4.2.3'
-  s.add_dependency 'omniauth', '~> 1.2.2'
+  s.add_dependency 'omniauth', '~> 1.3', '>= 1.3.2'
   s.add_dependency 'resque', '~> 1.25.2'
   s.add_dependency 'resque-scheduler', '~> 4.0.0'
   s.add_dependency 'jbuilder', '~> 2.0'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autotune",
   "description": "Platform and UI for creating new websites and html snippets from templates stored in git repos.",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "homepage": "https://github.com/voxmedia/autotune",
   "author": {
     "name": "Ryan Mark",


### PR DESCRIPTION
### Context

This is a security update for [this omniauth issue](https://github.com/omniauth/omniauth/pull/867).

For more information on this change, including changes made in other projects, see our [trello card](https://trello.com/c/mZLGAMaW/657-security-update-omniauth-chorus-to-avoid-leaking-csrf-token).