### PR TITLE
Make current_user available to deployers

### DIFF
--- a/app/controllers/autotune/projects_controller.rb
+++ b/app/controllers/autotune/projects_controller.rb
@@ -175,10 +175,10 @@ module Autotune
       end
 
       # Get the deployer object
-      deployer = @project.deployer(:preview)
+      deployer = @project.deployer(:preview, :user => current_user)
 
       # Run the before build deployer hook
-      deployer.before_build(@build_data, {}, current_user)
+      deployer.before_build(@build_data, {})
       render :json => @build_data
     rescue => exc
       if @project && @project.meta.present? && @project.meta['error_message'].present?

--- a/app/controllers/autotune/sessions_controller.rb
+++ b/app/controllers/autotune/sessions_controller.rb
@@ -3,8 +3,8 @@ require_dependency 'autotune/application_controller'
 module Autotune
   # Handle authentication and user sessions
   class SessionsController < ApplicationController
-    skip_before_action :require_login, :only => [:new, :create, :failure]
-    skip_before_action :require_google_login, :only => [:new, :create, :failure, :destroy]
+    skip_before_action :require_login, :only => %i[new create failure]
+    skip_before_action :require_google_login, :only => %i[new create failure destroy]
 
     def auth_dev_tools
       redirect_to "http://localhost:8080/?api_key=#{current_user.api_key}"
@@ -72,6 +72,7 @@ module Autotune
       elsif auth.persisted?
         # Visitor is trying to log in and they're already in the database
         # Update group permissions and log the user in!
+        auth.save
         auth.user.update_membership
         self.current_user = auth.user
       else

--- a/app/jobs/autotune/build_job.rb
+++ b/app/jobs/autotune/build_job.rb
@@ -42,10 +42,10 @@ module Autotune
 
       # Get the deployer object
       deployer = Autotune.new_deployer(
-        target.to_sym, project, :logger => outlogger)
+        target.to_sym, :user => current_user, :project => project, :logger => outlogger)
 
       # Run the before build deployer hook
-      deployer.before_build(build_data, repo.env, current_user)
+      deployer.before_build(build_data, repo.env)
 
       # Run the build
       repo.cd { |s| s.run(BLUEPRINT_BUILD_COMMAND, :stdin_data => build_data.to_json) }

--- a/app/jobs/autotune/sync_blueprint_job.rb
+++ b/app/jobs/autotune/sync_blueprint_job.rb
@@ -58,10 +58,10 @@ module Autotune
             # Get the deployer object
             # probably don't want this to always be preview
             deployer = Autotune.new_deployer(
-              :media, blueprint, :extra_slug => slug)
+              :media, :user => current_user, :project => blueprint, :extra_slug => slug)
 
             # Run the before build deployer hook
-            deployer.before_build(build_data, repo.env, current_user)
+            deployer.before_build(build_data, repo.env)
 
             # Run the build
             repo.cd { |s| s.run BLUEPRINT_BUILD_COMMAND, :stdin_data => build_data.to_json }

--- a/app/models/autotune/authorization.rb
+++ b/app/models/autotune/authorization.rb
@@ -23,8 +23,8 @@ module Autotune
 
     def update_from_auth_hash(auth_hash)
       # update user meta as well
-      user.update_roles(roles) if preferred?
       update(auth_hash.to_hash)
+      user.update_roles(roles) if preferred?
     end
 
     def update_from_auth_hash!(auth_hash)

--- a/app/models/autotune/blueprint.rb
+++ b/app/models/autotune/blueprint.rb
@@ -40,9 +40,9 @@ module Autotune
 
     # Gets the thumbnail image url for the blueprint
     # @return [String] thumbnail url.
-    def thumb_url
+    def thumb_url(current_user)
       if config['thumbnail'].present?
-        deployer(:media).url_for(config['thumbnail'])
+        deployer(:media, :user => current_user).url_for(config['thumbnail'])
       else
         ActionController::Base.helpers.asset_path('autotune/at_placeholder.png')
       end

--- a/app/models/autotune/project.rb
+++ b/app/models/autotune/project.rb
@@ -187,14 +187,14 @@ module Autotune
 
     # Gets the URL for previewing the project.
     # @return [String] preview URL for the project.
-    def preview_url
-      @preview_url ||= deployer(:preview).url_for('/')
+    def preview_url(current_user)
+      @preview_url ||= deployer(:preview, :user => current_user).url_for('/')
     end
 
     # Gets the URL to the published version of the project.
     # @return [String] publish URL for the project.
-    def publish_url
-      @publish_url ||= deployer(:publish).url_for('/')
+    def publish_url(current_user)
+      @publish_url ||= deployer(:publish, :user => current_user).url_for('/')
     end
 
     # Gets the slug of the project without the theme.

--- a/app/models/concerns/autotune/deployable.rb
+++ b/app/models/concerns/autotune/deployable.rb
@@ -22,7 +22,7 @@ module Autotune
       @deployers ||= {}
       key = kwargs.any? ? "#{target}:#{kwargs.to_query}" : target
       @deployers[key] ||=
-        Autotune.new_deployer(target.to_sym, self, **kwargs)
+        Autotune.new_deployer(target.to_sym, **kwargs.dup.update(:project => self))
     end
 
     # Has this deployable been deployed?
@@ -48,7 +48,7 @@ module Autotune
     # @return [String] Auth token
     def user_token_for_provider(provider)
       if respond_to?(:user)
-        user.authorizations.find_by_provider!(provider).credentials['token']
+        user.authorizations.find_by!(:provider => provider).credentials['token']
       end
     end
 

--- a/app/views/autotune/blueprints/_blueprint.json.jbuilder
+++ b/app/views/autotune/blueprints/_blueprint.json.jbuilder
@@ -1,7 +1,7 @@
 json.extract!(
   blueprint,
   :status, :mode, :id, :slug, :title, :type,
-  :repo_url, :config, :created_at, :updated_at,
-  :thumb_url, :version)
+  :repo_url, :config, :created_at, :updated_at, :version)
+json.thumb_url blueprint.thumb_url(current_user)
 
-json.media_url blueprint.deployer(:media).url_for('/')
+json.media_url blueprint.deployer(:media, :user => current_user).url_for('/')

--- a/app/views/autotune/projects/_project.json.jbuilder
+++ b/app/views/autotune/projects/_project.json.jbuilder
@@ -1,8 +1,11 @@
 json.extract!(
   project,
   :status, :id, :blueprint_id, :slug, :title, :created_at, :updated_at,
-  :preview_url, :publish_url, :user_id, :published_at, :data_updated_at,
+  :user_id, :published_at, :data_updated_at,
   :blueprint_version, :blueprint_repo_url, :bespoke)
+
+json.preview_url project.preview_url(current_user)
+json.publish_url project.publish_url(current_user)
 
 json.built project.built?
 json.type project.type
@@ -16,9 +19,9 @@ json.created_by project.user.name
 
 if project.built? && (!project.live? || project.published?)
   if project.publishable? && !project.live?
-    deployer = project.deployer(:preview)
+    deployer = project.deployer(:preview, :user => current_user)
   else
-    deployer = project.deployer(:publish)
+    deployer = project.deployer(:publish, :user => current_user)
   end
 
   json.screenshot_sm_url deployer.url_for('screenshots/screenshot_s.png')

--- a/lib/autotune/deployer.rb
+++ b/lib/autotune/deployer.rb
@@ -6,13 +6,14 @@ module Autotune
   # Autotune blueprint base deployer
   class Deployer
     attr_accessor :base_url, :connect, :project, :extra_slug
-    attr_writer :logger
+    attr_writer :logger, :user
 
     # Create a new deployer
     def initialize(kwargs)
       kwargs.each do |k, v|
         send "#{k}=".to_sym, v
       end
+      raise 'missing deployable' if kwargs[:project].nil?
     end
 
     # Deploy an entire directory
@@ -26,9 +27,9 @@ module Autotune
     end
 
     # Hook for adjusting data and files before build
-    def before_build(build_data, _env, current_user = nil)
-      if build_data['google_doc_url'].present? && current_user
-        current_auth = current_user.authorizations.find_by!(:provider => 'google_oauth2')
+    def before_build(build_data, _env)
+      if build_data['google_doc_url'].present? && user.present?
+        current_auth = user.authorizations.find_by!(:provider => 'google_oauth2')
         if current_auth.present?
           google_client = GoogleDocs.new(
             :refresh_token => current_auth.credentials['refresh_token'],
@@ -136,11 +137,15 @@ module Autotune
     end
 
     def take_screenshots?
-      repo.command?('phantomjs') && !Rails.env.test?
+      project.build_shell.command?('phantomjs') && !Rails.env.test?
     end
 
     def logger
       @logger ||= Rails.logger
+    end
+
+    def user
+      @user ||= project.user
     end
 
     private

--- a/test/controllers/autotune/projects_controller_test.rb
+++ b/test/controllers/autotune/projects_controller_test.rb
@@ -132,7 +132,7 @@ module Autotune
         if k == :theme
           assert_equal Autotune::Theme.find_by_slug(project_data[k]), new_p.send(k)
         elsif k == :preview_url
-          assert_equal '/preview/theme1-new-project', new_p.send(k)
+          assert_equal '/preview/theme1-new-project', new_p.send(k, autotune_users(:superuser))
         elsif k == :data
           assert_equal({ 'google_doc_id' => '1234' }, new_p.send(k))
         else
@@ -164,7 +164,7 @@ module Autotune
         if k == :theme
           assert_equal Autotune::Theme.find_by_slug(project_data[k]), new_p.send(k)
         elsif k == :preview_url
-          assert_equal '/preview/theme1-new-project', new_p.send(k)
+          assert_equal '/preview/theme1-new-project', new_p.send(k, autotune_users(:superuser))
         elsif k == :data
           assert_equal({ 'google_doc_id' => '1234' }, new_p.send(k))
         else

--- a/test/jobs/autotune/sync_blueprint_job_test.rb
+++ b/test/jobs/autotune/sync_blueprint_job_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 # Test the install blueprint job
 class Autotune::SyncBlueprintJobTest < ActiveJob::TestCase
   fixtures 'autotune/blueprints', 'autotune/projects', 'autotune/themes',
-           'autotune/groups'
+           'autotune/groups', 'autotune/users'
   test 'install blueprint' do
     bp = autotune_blueprints(:example)
     assert_equal 'new', bp.status
@@ -23,7 +23,7 @@ class Autotune::SyncBlueprintJobTest < ActiveJob::TestCase
     assert_equal 'built', bp.status
     assert_equal 'testing', bp.mode
 
-    assert_equal '/media/example-blueprint/thumbnail.jpg', bp.thumb_url
+    assert_equal '/media/example-blueprint/thumbnail.jpg', bp.thumb_url(autotune_users(:superuser))
   end
 
   test 'blueprint versioning' do
@@ -271,7 +271,7 @@ class Autotune::SyncBlueprintJobTest < ActiveJob::TestCase
 
     Autotune::Theme.where(:parent => nil).each do |theme|
       slug = [bp.version, theme.slug].join('-')
-      deployer = Autotune.new_deployer(:media, bp, :extra_slug => slug)
+      deployer = Autotune.new_deployer(:media, :project => bp, :extra_slug => slug)
 
       skip unless deployer.is_a?(Autotune::Deployers::File)
 
@@ -355,7 +355,7 @@ class Autotune::SyncBlueprintJobTest < ActiveJob::TestCase
 
     Autotune::Theme.where(:parent => nil).each do |theme|
       slug = [bp.version, theme.slug].join('-')
-      deployer = Autotune.new_deployer(:media, bp, :extra_slug => slug)
+      deployer = Autotune.new_deployer(:media, :project => bp, :extra_slug => slug)
 
       skip unless deployer.is_a?(Autotune::Deployers::File)
 

--- a/test/models/autotune/blueprint_test.rb
+++ b/test/models/autotune/blueprint_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module Autotune
   # Tesing the Blueprint model
   class BlueprintTest < ActiveSupport::TestCase
-    fixtures 'autotune/blueprints'
+    fixtures 'autotune/blueprints', 'autotune/users'
 
     test 'creating blueprints' do
       repo_url = autotune_blueprints(:example).repo_url
@@ -101,7 +101,7 @@ module Autotune
     test 'thumb url' do
       assert_equal(
         ActionController::Base.helpers.asset_path('autotune/at_placeholder.png'),
-        autotune_blueprints(:example).thumb_url)
+        autotune_blueprints(:example).thumb_url(autotune_users(:superuser)))
     end
   end
 end


### PR DESCRIPTION
Autotune has been using the credentials of the user who created a project or blueprint and not the credentials of the user who is viewing, editing or building projects.

Because of this, if a user's credentials expire, it can break parts of Autotune for users with valid credentials and access to google docs or other external applications (Like Vox's CMS).

This PR refactors parts of autotune to pass the `current_user` through to all places where deployer objects may need to make API calls. Previously, only the project or blueprint model was passed along, so we had to use the user associated with the model.

This changes the API of deployer objects:
- Project or blueprints are now passed to `Autotune.new_deployer` as a hash argument instead of a position argument.
- `Autotune.new_deployer` also takes a `:user` hash parameter in addition to existing params.
- The `deployer` method of model instances also takes an optional `:user` hash parameter
- If no `:user` param is provided, the creator user is used by default.
- Other code which uses the `deployer` method of model instances must take a user param to pass to the `deployer`. `Blueprint#thumb_url`, `Project#preview_url`, `Project#publish_url` now require a `user` positional param.