### PR TITLE
Refactor of deployers and bugfixes

### DIFF
--- a/app/controllers/autotune/projects_controller.rb
+++ b/app/controllers/autotune/projects_controller.rb
@@ -138,7 +138,7 @@ module Autotune
       if @project.valid?
         @project.status = 'built' if @project.live?
         @project.save
-        @project.build unless @project.live?
+        @project.build(current_user) unless @project.live?
 
         render :show, :status => :created
       else
@@ -155,7 +155,7 @@ module Autotune
       if @project.valid?
         @project.status = 'built' if @project.live?
         @project.save
-        @project.build unless @project.live?
+        @project.build(current_user) unless @project.live?
 
         render :show
       else
@@ -217,17 +217,17 @@ module Autotune
     end
 
     def update_snapshot
-      instance.update_snapshot
+      instance.update_snapshot(current_user)
       render_accepted
     end
 
     def build
-      instance.build
+      instance.build(current_user)
       render_accepted
     end
 
     def build_and_publish
-      instance.build_and_publish
+      instance.build_and_publish(current_user)
       render_accepted
     end
 

--- a/app/controllers/autotune/sessions_controller.rb
+++ b/app/controllers/autotune/sessions_controller.rb
@@ -100,17 +100,8 @@ module Autotune
     end
 
     def destroy
-      self.current_user = nil
-      render_error('You have been logged out.', :ok)
-    end
-
-    def current_user=(u)
-      @current_user = u
-      if u.nil?
-        session.delete(:api_key)
-      else
-        session[:api_key] = u.api_key
-      end
+      logout!
+      render_error('You have been logged out. <a href="/">Log in</a>.', :ok)
     end
 
     private

--- a/app/jobs/autotune/build_job.rb
+++ b/app/jobs/autotune/build_job.rb
@@ -45,7 +45,7 @@ module Autotune
         target.to_sym, project, :logger => outlogger)
 
       # Run the before build deployer hook
-      deployer.before_build(build_data, repo.env, current_user)
+      deployer.before_build(build_data, repo.env, :current_user => current_user)
 
       # Run the build
       repo.cd { |s| s.run(BLUEPRINT_BUILD_COMMAND, :stdin_data => build_data.to_json) }
@@ -71,7 +71,7 @@ module Autotune
       end
 
       # Set status and save project
-      project.published_at = DateTime.current if target.to_sym == :publish
+      project.update_published_at = true if target.to_sym == :publish
       project.status = 'built'
     rescue => exc
       # If the command failed, raise a red flag

--- a/app/jobs/autotune/build_job.rb
+++ b/app/jobs/autotune/build_job.rb
@@ -15,21 +15,13 @@ module Autotune
     unique_job :with => :payload
 
     def perform(project, target: 'preview', current_user: nil)
-      # Setup a new logger that logs to a string. The resulting log will
-      # be saved to the output field of the project.
-      out = StringIO.new
-      outlogger = Logger.new out
-      outlogger.formatter = proc do |severity, datetime, _progname, msg|
-        "#{datetime.strftime('%b %e %H:%M %Z')}\t#{severity}\t#{msg}\n"
-      end
-
       # Reset any previous error messages:
       project.meta.delete('error_message')
 
       # Create a new repo object based on the projects working dir
       repo = Autoshell.new(project.working_dir,
                            :env => Rails.configuration.autotune.build_environment,
-                           :logger => outlogger)
+                           :logger => project.output_logger)
 
       # Make sure the repo exists and is up to date (if necessary)
       raise 'Missing files!' unless repo.exist?
@@ -41,8 +33,7 @@ module Autotune
       current_user ||= project.user
 
       # Get the deployer object
-      deployer = Autotune.new_deployer(
-        target.to_sym, :user => current_user, :project => project, :logger => outlogger)
+      deployer = project.deployer(target.to_sym, :user => current_user)
 
       # Run the before build deployer hook
       deployer.before_build(build_data, repo.env)
@@ -80,14 +71,10 @@ module Autotune
       else
         msg = exc.message + "\n" + exc.backtrace.join("\n")
       end
-      logger.error(msg)
-      outlogger.error(msg)
       project.status = 'broken'
       raise
     ensure
       # Always make sure to save the log and the project
-      outlogger.close
-      project.output = out.try(:string)
       project.save!
     end
 

--- a/app/jobs/autotune/sync_blueprint_job.rb
+++ b/app/jobs/autotune/sync_blueprint_job.rb
@@ -11,7 +11,7 @@ module Autotune
 
     # do the deed
     def perform(blueprint, update: false, build_themes: false, current_user: nil)
-      return unless blueprint.sync_from_repo(update: update) || build_themes
+      return unless blueprint.sync_from_repo(update: update, current_user: current_user) || build_themes
 
       if blueprint.config['preview_type'] == 'live' && blueprint.config['sample_data']
         repo = blueprint.build_shell
@@ -21,23 +21,22 @@ module Autotune
           sample_data = repo.read(blueprint.config['sample_data'])
           sample_data.delete('base_url')
           sample_data.delete('asset_base_url')
-          sample_data.delete('available_themes') unless sample_data['available_themes'].blank?
-          sample_data.delete('theme_data') unless sample_data['theme_data'].blank?
+          sample_data.delete('available_themes') if sample_data['available_themes'].present?
+          sample_data.delete('theme_data') if sample_data['theme_data'].present?
 
           # add themes data if this blueprint support themeing
           if blueprint.themable?
-            sample_data.merge!(
-              'available_themes' => Theme.all.pluck(:slug),
-              'theme_data' => Theme.full_theme_data
-            )
+            sample_data['available_themes'] = Theme.all.pluck(:slug)
+            sample_data['theme_data'] = Theme.full_theme_data
           end
 
           # if no theme list is available, pick the first theme
-          if blueprint.config['themes'].blank?
-            themes = blueprint.themable? ? [Theme.first] : Theme.where(:parent => nil)
-          else # get supported themes
-            themes = Theme.where(:slug => blueprint.config['themes'])
-          end
+          themes =
+            if blueprint.config['themes'].blank?
+              blueprint.themable? ? [Theme.first] : Theme.where(:parent => nil)
+            else # get supported themes
+              Theme.where(:slug => blueprint.config['themes'])
+            end
 
           # if no theme is selected at this point, use any default theme
           themes = Theme.where(:parent => nil).first if themes.empty?

--- a/app/jobs/autotune/sync_blueprint_job.rb
+++ b/app/jobs/autotune/sync_blueprint_job.rb
@@ -56,8 +56,7 @@ module Autotune
 
             # Get the deployer object
             # probably don't want this to always be preview
-            deployer = Autotune.new_deployer(
-              :media, :user => current_user, :project => blueprint, :extra_slug => slug)
+            deployer = blueprint.deployer(:media, :user => current_user, :extra_slug => slug)
 
             # Run the before build deployer hook
             deployer.before_build(build_data, repo.env)

--- a/app/jobs/autotune/sync_project_job.rb
+++ b/app/jobs/autotune/sync_project_job.rb
@@ -9,9 +9,9 @@ module Autotune
       arguments.first.to_gid_param
     end
 
-    def perform(project, update: false)
+    def perform(project, update: false, current_user: nil)
       if project.bespoke?
-        project.sync_from_repo(update: update)
+        project.sync_from_repo(update: update, current_user: current_user)
       else
         # Make sure the blueprint has a version
         raise 'Missing blueprint version' if project.blueprint.version.blank?

--- a/app/models/autotune/project.rb
+++ b/app/models/autotune/project.rb
@@ -124,7 +124,7 @@ module Autotune
       end
 
       chain
-        .then(SyncProjectJob.new(self, :update => true))
+        .then(SyncProjectJob.new(self, :update => true, :current_user => current_user))
         .then(BuildJob.new(self,
                            :target => publishable? ? 'preview' : 'publish',
                            :current_user => current_user))
@@ -155,7 +155,7 @@ module Autotune
       end
 
       chain
-        .then(SyncProjectJob.new(self))
+        .then(SyncProjectJob.new(self, :current_user => current_user))
         .then(BuildJob.new(self,
                            :target => publishable? ? 'preview' : 'publish',
                            :current_user => current_user))
@@ -186,7 +186,7 @@ module Autotune
       end
 
       chain
-        .then(SyncProjectJob.new(self))
+        .then(SyncProjectJob.new(self, :current_user => current_user))
         .then(BuildJob.new(self,
                            :target => 'publish',
                            :current_user => current_user))
@@ -275,6 +275,8 @@ module Autotune
         self.published_at = now
         self.update_published_at = false
       end
+
+      true # make sure we return true to continue the save
     end
 
     def pub_to_redis

--- a/app/models/autotune/project.rb
+++ b/app/models/autotune/project.rb
@@ -107,14 +107,14 @@ module Autotune
     # @raise The original exception when the update fails
     # @see build
     # @see build_and_publish
-    def update_snapshot(current_user = nil)
+    def update_snapshot(current_user)
       self.status = 'building'
       unless bespoke? || blueprint_version == blueprint.version
         self.blueprint_version = blueprint.version
         self.blueprint_config = blueprint.config
       end
 
-      deployer(publishable? ? 'preview' : 'publish').prep_target(:current_user => current_user)
+      deployer(publishable? ? 'preview' : 'publish', :user => current_user).prep_target
 
       save!
 
@@ -142,10 +142,10 @@ module Autotune
     # @raise The original exception when the update fails
     # @see build_and_publish
     # @see update_snapshot
-    def build(current_user = nil)
+    def build(current_user)
       self.status = 'building'
 
-      deployer(publishable? ? 'preview' : 'publish').prep_target(:current_user => current_user)
+      deployer(publishable? ? 'preview' : 'publish', :user => current_user).prep_target
 
       save!
 
@@ -173,10 +173,10 @@ module Autotune
     # @see build
     # @see update_snapshot
     # @raise The original exception when the update fails
-    def build_and_publish(current_user = nil)
+    def build_and_publish(current_user)
       self.status = 'building'
 
-      deployer('publish').prep_target(:current_user => current_user)
+      deployer('publish', :user => current_user).prep_target
 
       save!
 

--- a/app/models/concerns/autotune/deployable.rb
+++ b/app/models/concerns/autotune/deployable.rb
@@ -12,7 +12,7 @@ module Autotune
     included do
       after_destroy :delete_deployed_files, :if => :deployed?
       after_save :delete_renamed_files, :if => :deployed?
-      after_save :deployer_after_save
+      before_save :deployer_before_save
     end
 
     # Get a deployer for a specfic target
@@ -23,7 +23,7 @@ module Autotune
       @deployers ||= {}
       key = kwargs.any? ? "#{target}:#{kwargs.to_query}" : target
       @deployers[key] ||=
-        Autotune.new_deployer(target.to_sym, **kwargs.dup.update(:project => self))
+        Autotune.new_deployer(target.to_sym, **kwargs.dup.update(:project => self, :logger => output_logger))
     end
 
     # Has this deployable been deployed?
@@ -53,10 +53,40 @@ module Autotune
       end
     end
 
+    # Get the contents of the logger as a string and reset the logger
+    # @return [String] The log
+    def dump_output_logger!
+      if defined?(@output_logger) && @output_logger.present?
+        @output_logger.close
+        str = @output_logger_str.try(:string)
+        @output_logger = nil
+        str if str.present?
+      end
+    end
+
+    def output_logger
+      return @output_logger if defined?(@output_logger) && @output_logger.present?
+
+      # Setup a new logger that logs to a string. The resulting log will
+      # be saved to the output field of the project.
+      @output_logger_str = StringIO.new
+      @output_logger = Logger.new @output_logger_str
+      @output_logger.formatter = proc do |severity, datetime, _progname, msg|
+        "#{datetime.strftime('%b %e %H:%M %Z')}\t#{severity}\t#{msg}\n"
+      end
+
+      @output_logger
+    end
+
     private
 
-    def deployer_after_save
-
+    def deployer_before_save
+      if respond_to? :output
+        # Always make sure to save the log
+        str = dump_output_logger!
+        self.output = str if str.present?
+      end
+      true
     end
 
     def delete_renamed_files

--- a/app/models/concerns/autotune/repo.rb
+++ b/app/models/concerns/autotune/repo.rb
@@ -13,7 +13,7 @@ module Autotune
     # run in the context of a job.
     # @param [Boolean] <update> Force an update from the remote repo url
     # @return [Boolean] True if anything was updated
-    def sync_from_repo(update: false)
+    def sync_from_repo(update: false, current_user: nil)
       raise 'Repo URL is missing' if repo_url.blank?
 
       repo = setup_shell
@@ -26,7 +26,7 @@ module Autotune
           # Update the repo
           repo.update
           self.version = repo.version
-        elsif status.in?(%w(built updated)) && version == repo.version
+        elsif status.in?(%w[built updated]) && version == repo.version
           return false # no syncing occurs
         elsif version.present?
           # we're not updating, but the repo is broken, so set it up
@@ -64,10 +64,10 @@ module Autotune
 
       # Stash the thumbnail
       if config['thumbnail'].present? && repo.exist?(config['thumbnail'])
-        deployer(:media).deploy_file(working_dir, config['thumbnail'])
+        deployer(:media, :user => current_user).deploy_file(working_dir, config['thumbnail'])
       end
 
-      return true
+      true
     end
   end
 end

--- a/appjs/views/edit_project.js
+++ b/appjs/views/edit_project.js
@@ -833,10 +833,9 @@ var EditProject = BaseView.extend(require('./mixins/actions'), require('./mixins
       dataType: 'json'
     }) ).then(
       function( data ) {
-        ctrl
-          .setValue(data.google_doc_url)
-          .refreshValidationState()
-          .focus();
+        ctrl.setValue(data.google_doc_url);
+        ctrl.refreshValidationState();
+        ctrl.focus();
       },
       function(err) {
         var msg = 'There was an error authenticating your Google account.';

--- a/appjs/views/mixins/actions.js
+++ b/appjs/views/mixins/actions.js
@@ -45,7 +45,7 @@ module.exports = {
 
     if ( model_class && model_id ) {
       if ( this.collection ) {
-        logger.debug('load model from collection');
+        logger.debug('load model '+model_id+' from collection');
         inst = this.collection.get( model_id );
       }
 

--- a/lib/autotune.rb
+++ b/lib/autotune.rb
@@ -29,6 +29,9 @@ module Autotune
                       :git_ssh, :git_askpass,
                       :redis, :faq_url, :generic_theme, :theme_meta_data, :get_theme_data)
 
+  class Unauthorized < StandardError; end
+  class Forbidden < StandardError; end
+
   class << self
     delegate :redis, :to => :configuration
 

--- a/lib/autotune/deployer.rb
+++ b/lib/autotune/deployer.rb
@@ -25,8 +25,13 @@ module Autotune
       raise NotImplementedError
     end
 
-    # Hook for adjusting data and files before build
-    def before_build(build_data, _env, current_user = nil)
+    # Hook for preparing the deployment target before the build job is queued.
+    # Project instance is saved after this method is run.
+    def prep_target(current_user: nil); end
+
+    # Hook for updating the data to be passed to the build script. Project
+    # instance is saved after this method runs.
+    def before_build(build_data, _env, current_user: nil)
       if build_data['google_doc_url'].present? && current_user
         current_auth = current_user.authorizations.find_by!(:provider => 'google_oauth2')
         if current_auth.present?

--- a/lib/autotune/deployer.rb
+++ b/lib/autotune/deployer.rb
@@ -164,18 +164,19 @@ module Autotune
 
       cache_key = "googledoc#{doc_key}"
 
+      resp = google_client.find(doc_key)
       if Rails.cache.exist?(cache_key)
         cache_value = Rails.cache.read(cache_key)
-        resp = google_client.find(doc_key)
         needs_update = cache_value['version'] && resp['version'] != cache_value['version']
       else
         needs_update = true
       end
 
+      # TODO: needs test coverage
       if needs_update
         google_client.share_with_domain(doc_key, Autotune.configuration.google_auth_domain)
-        ret = google_client.get_doc_contents(build_data['google_doc_url'])
-        Rails.cache.write(cache_key, 'ss_data' => ss_data, 'version' => resp['version'])
+        ret = google_client.get_doc_contents(url)
+        Rails.cache.write(cache_key, 'ss_data' => ret, 'version' => resp['version'])
       else
         ret = Rails.cache.read(cache_key)['ss_data']
       end

--- a/test/models/autotune/project_test.rb
+++ b/test/models/autotune/project_test.rb
@@ -250,7 +250,7 @@ module Autotune
       project = autotune_projects(:example_one)
 
       assert_performed_jobs 3 do
-        project.build_and_publish
+        project.build_and_publish(autotune_users(:superuser))
       end
     end
 
@@ -258,7 +258,7 @@ module Autotune
       project = autotune_projects(:example_one)
 
       assert_performed_jobs 3 do
-        project.build
+        project.build(autotune_users(:superuser))
       end
     end
 
@@ -266,7 +266,7 @@ module Autotune
       project = autotune_projects(:example_one)
 
       assert_performed_jobs 3 do
-        project.update_snapshot
+        project.update_snapshot(autotune_users(:superuser))
       end
     end
 


### PR DESCRIPTION
## Purpose
To streamline and speed up building, and bugfixes.

## Changes
- Added `prep_target` method to deployers. This method is called when a project is saved, published or a build or upgrade is triggered. This allows Autotune to do API calls to 3rd party services like google docs immediately and notify the user if there are any problems.
- The route `/logout` now clears a users Google Authorization and forces a new Google login. This should solve occasional issues where the google authorization expires and can't be refreshed automatically.
- Any auth error from google or other 3rd party APIs in the deployer `prep_target` triggers a logout and clears the users google auth.
- Moved build logger handling out of build_job into the `deployable` concern.
- Now passing current_user through to jobs so the current_user auth is used for making API calls instead of the project or blueprint creator's auth
- Google doc entry fields properly update validation status after clicking create google doc link.