### PR TITLE
Add support for passing in google doc format

### DIFF
--- a/app/controllers/autotune/projects_controller.rb
+++ b/app/controllers/autotune/projects_controller.rb
@@ -168,17 +168,12 @@ module Autotune
 
       @build_data = request.method == 'POST' ? request.POST : @project.data
 
-      # Bust google doc cache if we are forcing an update
-      if @build_data['google_doc_url'].present? && request.GET[:force_update]
-        cache_key = "googledoc#{GoogleDocs.key_from_url(@build_data['google_doc_url'])}"
-        Rails.cache.delete(cache_key)
-      end
-
       # Get the deployer object
       deployer = @project.deployer(:preview, :user => current_user)
 
       # Run the before build deployer hook
-      deployer.before_build(@build_data, {})
+      # set an env var to bust google doc cache if we are forcing an update
+      deployer.before_build(@build_data, 'FORCE_UPDATE' => request.GET[:force_update].nil?)
       render :json => @build_data
     rescue
       if @project && @project.meta.present? && @project.meta['error_message'].present?


### PR DESCRIPTION
This change is to support passing in output format with google docs.
Use case: Be able to retrieve text or raw html from google docs.

Autotune now supports configs in the following formats

#### Single url
Configs of the format `google_doc_url[_format]: { "type": "string" }`
Eg: `google_doc_url`, `google_doc_url_text`, etc

#### Array of urls
Configs of the format `google_docs[_format] : {type: "array" }`
Eg: `google_docs`, `google_docs_text`, `google_docs_html`, etc
