### PR TITLE
Scheduled building

### DIFF
--- a/app/controllers/autotune/projects_controller.rb
+++ b/app/controllers/autotune/projects_controller.rb
@@ -213,26 +213,36 @@ module Autotune
       render :json => { :google_doc_url => doc_copy[:url] }
     end
 
-    def update_snapshot
-      instance.update_snapshot(current_user)
-      render_accepted
-    end
-
     def cancel_repeat_build
       instance.cancel_repeat_build!
       render_accepted
     end
 
     def build
+      kwargs = {}
       if params[:repeat_until].present?
-        instance.repeat_build!(Time.zone.at(params[:repeat_until].to_i))
+        kwargs[:repeat_until] = Time.zone.at(params[:repeat_until].to_i)
       end
-      instance.build(current_user)
+      if params[:wait_until].present?
+        kwargs[:wait_until] = Time.zone.at(params[:wait_until].to_i)
+      end
+      if params[:publish].present? && params[:publish]
+        kwargs[:publish] = true
+      end
+      if params[:update].present? && params[:update]
+        kwargs[:update] = true
+      end
+      instance.build(current_user, kwargs)
       render_accepted
     end
 
     def build_and_publish
-      instance.build_and_publish(current_user)
+      instance.build(current_user, :publish => True)
+      render_accepted
+    end
+
+    def update_snapshot
+      instance.build(current_user, :update => True)
       render_accepted
     end
 

--- a/app/jobs/autotune/project_job.rb
+++ b/app/jobs/autotune/project_job.rb
@@ -18,8 +18,8 @@ module Autotune
       if project.bespoke?
         project.sync_from_remote(:update => update, :current_user => current_user)
       else
-        # make sure blueprint is synced before syncing from it
         if project.blueprint.needs_sync?
+        # make sure blueprint is synced before syncing from it
           project.blueprint.with_file_lock do |has_lock|
             if has_lock
               project.blueprint.sync_from_remote(:current_user => current_user)
@@ -94,8 +94,8 @@ module Autotune
       project.file_unlock!
       project.save!
 
-      project.build(current_user) if project.repeat_build?
-    rescue => exc
+      project.build(current_user, :publish => target == :publish) if project.repeat_build?
+    rescue StandardError => exc
       project.output = project.dump_output_logger!
       # If the command failed, raise a red flag
       msg = \
@@ -112,9 +112,13 @@ module Autotune
       project.file_unlock!
       project.save!
 
-      project.build(current_user) if project.repeat_build?
+      project.build(current_user, :publish => target == :publish) if project.repeat_build?
 
       raise
+    end
+
+    def unique_lock?
+      Autotune.lock?(unique_lock_key)
     end
 
     private

--- a/app/models/autotune/project.rb
+++ b/app/models/autotune/project.rb
@@ -105,45 +105,38 @@ module Autotune
     # and build the new project.
     # It publishes updates on projects already published.
     # @raise The original exception when the update fails
-    # @see build
     # @see build_and_publish
-    def update_snapshot(current_user)
+    # @see update_snapshot
+    def build(current_user, update: false, publish: false, repeat_until: nil, wait_until: nil)
       self.status = 'building'
-      unless bespoke? || blueprint_version == blueprint.version
+
+      # If this is a blueprint-based project and an update is requested, update
+      # the version and config data from the blueprint
+      if update && !bespoke? && blueprint_version != blueprint.version
         self.blueprint_version = blueprint.version
         self.blueprint_config = blueprint.config
       end
 
-      dep = deployer(publishable? ? 'preview' : 'publish', :user => current_user)
-      dep.prep_target
-      dep.after_prep_target
-
-      save!
-
-      ProjectJob.new(self, :update => true, :current_user => current_user).enqueue
-    rescue
-      update!(:status => 'broken')
-      raise
-    end
-
-    # Updates blueprint version and builds the project.
-    # Queues jobs to sync latest verison of blueprint, update it on the project
-    # and build the new project.
-    # It publishes updates on projects already published.
-    # @raise The original exception when the update fails
-    # @see build_and_publish
-    # @see update_snapshot
-    def build(current_user)
-      self.status = 'building'
-      target = publishable? ? 'preview' : 'publish'
+      target = publishable? && !publish ? 'preview' : 'publish'
 
       dep = deployer(target, :user => current_user)
       dep.prep_target
       dep.after_prep_target
 
+      job = ProjectJob.new(
+        self, :update => update, :target => target, :current_user => current_user
+      )
+      return if job.unique_lock?
+
       save!
 
-      ProjectJob.new(self, :target => target, :current_user => current_user).enqueue
+      repeat_build!(Time.zone.at(repeat_until.to_i)) if repeat_until.present?
+
+      if wait_until
+        job.enqueue(:wait_until => wait_until)
+      else
+        job.enqueue
+      end
     rescue
       update!(:status => 'broken')
       raise
@@ -154,21 +147,19 @@ module Autotune
     # Queues jobs to sync latest verison of blueprint, update it on the project
     # and build the new project.
     # @see build
-    # @see update_snapshot
     # @raise The original exception when the update fails
     def build_and_publish(current_user)
-      self.status = 'building'
+      build(current_user, :publish => true)
+    end
 
-      dep = deployer('publish', :user => current_user)
-      dep.prep_target
-      dep.after_prep_target
-
-      save!
-
-      ProjectJob.new(self, :target => 'publish', :current_user => current_user).enqueue
-    rescue
-      update!(:status => 'broken')
-      raise
+    # Updates blueprint version and builds the project.
+    # Queues jobs to sync latest verison of blueprint, update it on the project
+    # and build the new project.
+    # It publishes updates on projects already published.
+    # @raise The original exception when the update fails
+    # @see build
+    def update_snapshot(current_user)
+      build(current_user, update: true)
     end
 
     # Gets the URL for previewing the project.

--- a/app/models/autotune/project.rb
+++ b/app/models/autotune/project.rb
@@ -137,7 +137,7 @@ module Autotune
       else
         job.enqueue
       end
-    rescue
+    rescue StandardError
       update!(:status => 'broken')
       raise
     end
@@ -159,7 +159,7 @@ module Autotune
     # @raise The original exception when the update fails
     # @see build
     def update_snapshot(current_user)
-      build(current_user, update: true)
+      build(current_user, :update => true)
     end
 
     # Gets the URL for previewing the project.

--- a/lib/autotune.rb
+++ b/lib/autotune.rb
@@ -96,7 +96,7 @@ module Autotune
     end
 
     def send_message(type, data)
-      ensure_redis
+      ensure_redis!
       dt = DateTime.current
       payload = { 'type' => type, 'time' => dt.utc.to_f, 'data' => data }
       redis.zadd('messages', dt.utc.to_f, payload.to_json)
@@ -106,7 +106,7 @@ module Autotune
     end
 
     def purge_messages(older_than: nil)
-      ensure_redis
+      ensure_redis!
       if older_than.nil?
         redis.del('messages')
       else
@@ -115,7 +115,7 @@ module Autotune
     end
 
     def messages(since: nil, type: nil)
-      ensure_redis
+      ensure_redis!
 
       results =
         if since.nil?
@@ -134,7 +134,7 @@ module Autotune
     end
 
     def lock!(name)
-      ensure_redis
+      ensure_redis!
       raise 'Empty lock name' if name.blank?
 
       ret = \
@@ -158,13 +158,13 @@ module Autotune
     end
 
     def lock?(name)
-      ensure_redis
+      ensure_redis!
       raise 'Empty lock name' if name.blank?
       redis.exists("lock:#{name}")
     end
 
     def unlock!(name)
-      ensure_redis
+      ensure_redis!
       raise 'Empty lock name' if name.blank?
       if redis.del("lock:#{name}") > 0
         Rails.logger.debug "Released lock #{name}"
@@ -177,7 +177,7 @@ module Autotune
 
     private
 
-    def ensure_redis
+    def ensure_redis!
       raise 'Redis is not configured' if redis.nil?
     end
   end


### PR DESCRIPTION
Changes:
- Merge Project#build_and_publish, Project#update_snapshot into Project#build
- Project#build now takes the following params: `publish`, `update`, `repeat_until` and `wait_until`
- Update ProjectController#update_snapshot, ProjectController#build_and_publish to use Project#build
- Update ProjectController#build and the `/project/id/build` endpoint to take the params `publish`, `update`, `repeat_until` and `wait_until`
- Check that the unique lock for a ProjectJob is free before updating a project DB record and submitting a ProjectJob. Hopefully will fix problems where a project shows up as `building` even tho its `built`.
- Address a bug where repeat building stops updating the published version of a project and switches to updating the preview version 

NOTE: these features are only available via the web API, this PR doesn't include any UI updates.